### PR TITLE
fix(ai-gate): watchdog fail-open on PR comment 403 + setup checklist

### DIFF
--- a/.github/workflows/codex-autofix-watchdog.yml
+++ b/.github/workflows/codex-autofix-watchdog.yml
@@ -22,6 +22,7 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const safeString = (value) => String(value || '');
 
             const queuedLimitMs = 3 * 60 * 1000;
             const inProgressLimitMs = 10 * 60 * 1000;
@@ -96,10 +97,17 @@ jobs:
                 continue;
               }
 
-              const issueComments = await github.paginate(
-                github.rest.issues.listComments,
-                { owner, repo, issue_number: stale.prNumber, per_page: 100 }
-              );
+              let issueComments = [];
+              try {
+                issueComments = await github.paginate(
+                  github.rest.issues.listComments,
+                  { owner, repo, issue_number: stale.prNumber, per_page: 100 }
+                );
+              } catch (listErr) {
+                core.warning(
+                  `Watchdog: failed to list PR comments for #${stale.prNumber}; continuing without marker dedupe: ${listErr}`
+                );
+              }
               const retryMarker = `<!-- codex-autofix:watchdog-retry sha=${stale.sha} attempt=2 -->`;
 
               if (stale.attempt >= 2) {
@@ -112,36 +120,49 @@ jobs:
                   `status=${stale.status}\n` +
                   `age_ms=${stale.ageMs}\n` +
                   `run=${stale.runUrl}`;
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number: stale.prNumber,
-                  body: noRetryMarker,
-                });
+                try {
+                  await github.rest.issues.createComment({
+                    owner,
+                    repo,
+                    issue_number: stale.prNumber,
+                    body: noRetryMarker,
+                  });
+                } catch (commentErr) {
+                  core.warning(
+                    `Watchdog: failed to write no-retry marker for pr=${stale.prNumber} sha=${stale.sha}: ${commentErr}`
+                  );
+                }
                 continue;
               }
 
-              const alreadyRetried = issueComments.some(c => String(c.body || '').includes(retryMarker));
+              const alreadyRetried = issueComments.some(c => safeString(c.body).includes(retryMarker));
               if (alreadyRetried) {
                 core.info(`Skip watchdog retry for pr=${stale.prNumber} sha=${stale.sha}: marker already exists.`);
                 continue;
               }
 
-              const retryComment = await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number: stale.prNumber,
-                body:
-                  `${retryMarker}\n` +
-                  `Watchdog cancelled stale autofix run and queued a single retry.\n\n` +
-                  `pr=#${stale.prNumber}\n` +
-                  `sha=${stale.sha}\n` +
-                  `status=${stale.status}\n` +
-                  `age_ms=${stale.ageMs}\n` +
-                  `cancelled_run=${stale.runUrl}\n` +
-                  `source=watchdog-stale-run`,
-              });
-              const retryCommentId = retryComment?.data?.id || null;
+              let retryCommentId = null;
+              try {
+                const retryComment = await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: stale.prNumber,
+                  body:
+                    `${retryMarker}\n` +
+                    `Watchdog cancelled stale autofix run and queued a single retry.\n\n` +
+                    `pr=#${stale.prNumber}\n` +
+                    `sha=${stale.sha}\n` +
+                    `status=${stale.status}\n` +
+                    `age_ms=${stale.ageMs}\n` +
+                    `cancelled_run=${stale.runUrl}\n` +
+                    `source=watchdog-stale-run`,
+                });
+                retryCommentId = retryComment?.data?.id || null;
+              } catch (commentErr) {
+                core.warning(
+                  `Watchdog: failed to write retry marker for pr=${stale.prNumber} sha=${stale.sha}; continuing: ${commentErr}`
+                );
+              }
 
               let batchDispatched = false;
               try {

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -53,6 +53,22 @@ flowchart LR
 
 ## Review Automation
 
+### Setup Checklist (required)
+
+Before expecting fully automatic review+autofix, verify:
+
+- **Codex connector**: connect this GitHub repo in Codex settings, otherwise bot replies with "create a Codex account and connect to github".
+- **Self-hosted runner**: at least one online runner with labels `self-hosted` and `codex`.
+- **Secrets**:
+  - `CODEX_REVIEW_TOKEN` (recommended) for comment/dispatch operations as connected user.
+  - `CODEX_API_KEY` only if you use API auth mode instead of ChatGPT login.
+  - `CODEX_SESSION_DISPATCH_URL` (+ optional `CODEX_SESSION_DISPATCH_TOKEN`) only if you use webhook relay.
+- **Labels**: ensure `needs-codex-fix` and `autofix/codex` exist in the repo.
+
+Notes:
+- If `CODEX_REVIEW_TOKEN` is absent or under-scoped, workflows use `GITHUB_TOKEN` fallback where possible.
+- `codex-autofix-watchdog` is fail-open for PR-comment write errors: it still cancels stale runs and continues retry flow.
+
 ### Codex Review
 
 - On PR open/reopened/ready_for_review/synchronize (non-draft, non-fork), a workflow posts `@codex review` automatically.


### PR DESCRIPTION
Fixes watchdog failure mode observed in smoke run:
- `codex-autofix-watchdog` previously crashed on `issues.createComment` 403 ("Resource not accessible by integration").

What changed
1) Watchdog is now fail-open for comment-path errors:
   - `issues.listComments` failures no longer abort the run.
   - `issues.createComment` failures (retry/no-retry markers) are logged as warnings and flow continues.
2) Added short "Setup Checklist (required)" section to `docs/WORKFLOW.md`:
   - Codex connector
   - self-hosted runner labels (`self-hosted`, `codex`)
   - required/optional secrets
   - label prerequisites

Validation
- YAML parse OK for `.github/workflows/*.yml` with PyYAML.
