### PR TITLE
ai-gate: post @codex commands as greatTribe

### DIFF
--- a/.github/workflows/codex-autofix-selfhosted.yml
+++ b/.github/workflows/codex-autofix-selfhosted.yml
@@ -681,16 +681,15 @@ jobs:
           echo "pushed=true" >> "$GITHUB_OUTPUT"
         env:
           DRY_RUN: ${{ steps.pr.outputs.dry_run }}
-
       - name: Request Codex rereview after autofix push
-        if: steps.pr.outputs.skip_run != 'true' && steps.commit.outputs.changes_applied == 'true' && steps.commit.outputs.pushed == 'true'
+        if: steps.pr.outputs.skip_run != 'true' && steps.commit.outputs.changes_applied == 'true' && steps.commit.outputs.pushed == 'true' && secrets.CODEX_REVIEW_TOKEN != ''
         uses: actions/github-script@v7
         env:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           REPO: ${{ steps.pr.outputs.repo }}
           NEW_SHA: ${{ steps.commit.outputs.new_sha }}
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.CODEX_REVIEW_TOKEN }}
           script: |
             const prNumber = Number(process.env.PR_NUMBER || 0);
             const repoFull = String(process.env.REPO || '');

--- a/.github/workflows/codex-review-automation.yml
+++ b/.github/workflows/codex-review-automation.yml
@@ -425,9 +425,10 @@ jobs:
           CODEX_REVIEW_TOKEN: ${{ secrets.CODEX_REVIEW_TOKEN }}
 
       - name: Comment @codex review on open/sync
+        if: steps.token.outputs.present == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || github.token }}
+          github-token: ${{ secrets.CODEX_REVIEW_TOKEN }}
           script: |
             const action = context.payload.action;
             const allowed = new Set(['opened', 'reopened', 'synchronize', 'ready_for_review']);
@@ -511,9 +512,10 @@ jobs:
           CODEX_REVIEW_TOKEN: ${{ secrets.CODEX_REVIEW_TOKEN }}
 
       - name: Comment @codex address that feedback when autofix/remote is added
+        if: steps.token.outputs.present == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || github.token }}
+          github-token: ${{ secrets.CODEX_REVIEW_TOKEN }}
           script: |
             const label = context.payload.label?.name;
             if (label !== 'autofix/remote') {

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -66,12 +66,12 @@ Before expecting fully automatic review+autofix, verify:
 - **Labels**: ensure `needs-codex-fix` and `autofix/codex` exist in the repo.
 
 Notes:
-- If `CODEX_REVIEW_TOKEN` is absent or under-scoped, workflows use `GITHUB_TOKEN` fallback where possible.
+- If `CODEX_REVIEW_TOKEN` is absent or under-scoped, workflows may fall back to `GITHUB_TOKEN` for labeling/dispatch, but will not post `@codex …` commands (Codex ignores `github-actions[bot]`).
 - `codex-autofix-watchdog` is fail-open for PR-comment write errors: it still cancels stale runs and continues retry flow.
 
 ### Codex Review
 
-- On PR open/reopened/ready_for_review/synchronize (non-draft, non-fork), a workflow posts `@codex review` automatically.
+- On PR open/reopened/ready_for_review/synchronize (non-draft, non-fork), a workflow posts `@codex review` automatically (requires `CODEX_REVIEW_TOKEN`).
 - Skip automation if `automation/off` or `no-bot` is present.
 - If Codex leaves inline feedback, a workflow adds the label `needs-codex-fix`.
 - Before manual fixes, check PR comments and commit history for autofix signals (e.g., comment "Dispatching autofix" and commits like "fix: address codex review feedback"); also look for the autofix result comment (`codex-autofix:result`) with a run link; verify if feedback is already resolved before rework.
@@ -103,7 +103,7 @@ Notes:
 ### Self-hosted Autofix (optional, fully automatic)
 
 - A self-hosted runner labeled `codex` can apply fixes directly via `workflow_dispatch` when `autofix/codex` + `needs-codex-fix` are present.
-- `CODEX_REVIEW_TOKEN` is optional; if not set the workflow uses `GITHUB_TOKEN` (comments will be authored by `github-actions[bot]`).
+- `CODEX_REVIEW_TOKEN` is optional for dispatch/labels, but required for workflow-generated `@codex …` comments (review/rereview/address) to be acted on by Codex.
 - Codex auth can be either ChatGPT device auth (preferred for subscription accounts) or API key (`CODEX_API_KEY`). This is controlled by `vars.CODEX_AUTOFIX_LOGIN_METHOD` (or workflow input `login_method`).
 - Default autofix model is `gpt-5.3-codex`; reasoning effort defaults to `xhigh` (`vars.CODEX_AUTOFIX_MODEL` / `vars.CODEX_AUTOFIX_REASONING_EFFORT` override).
 - The workflow uses Codex CLI and pushes changes back to the PR branch.


### PR DESCRIPTION
Fixes: automation posting `@codex …` as `github-actions[bot]` (Codex ignores those).

Changes:
- Only post workflow-generated `@codex review` and `@codex address that feedback` when `CODEX_REVIEW_TOKEN` is present, using that PAT so the author is the connected user.
- Only post self-hosted rerreview `@codex review` after autofix push when `CODEX_REVIEW_TOKEN` is present.
- Docs: clarify PAT requirement for `@codex …` commands.

After merge: add repo secret `CODEX_REVIEW_TOKEN` (PAT for greatTribe) so PR #31 gets automatic review again.