### PR TITLE
fix(data): allow --h height in iso-vertex-nbpro

### DIFF
--- a/packages/data/scripts/iso-vertex-nbpro.mjs
+++ b/packages/data/scripts/iso-vertex-nbpro.mjs
@@ -323,7 +323,9 @@ export async function runIsoVertexNbpro({
 
 async function main() {
   const { args } = parseArgs(process.argv.slice(2));
-  if (args.help || args.h) {
+  // parseArgs() treats `--h=<value>` as `args.h`, so don't use `args.h` for help.
+  // Only `--help` is supported.
+  if (args.help) {
     printHelp();
     process.exit(0);
   }


### PR DESCRIPTION
Fixes a CLI correctness bug: `iso-vertex-nbpro` used `args.h` as a help alias, which conflicts with `--h=<height>` and causes the command to print help and exit instead of running.

Change:
- Only treat `--help` as help; `--h` is reserved for height.

Why:
- Without this, the nbpro pilot cannot be run with any non-default height.

Checks:
- node --check packages/data/scripts/iso-vertex-nbpro.mjs
- pnpm -C packages/data lint