### PR TITLE
feat(data): NBPro pilot optional color-reference tiles

### DIFF
--- a/docs/tasks/vertex-nanobanana-4x4-prototype.md
+++ b/docs/tasks/vertex-nanobanana-4x4-prototype.md
@@ -27,6 +27,9 @@ This is intended to answer: can we get “isometric.nyc-level” quality and wha
 - `--tiles_dir`: run-relative directory that contains `tilejson.json` and the whitebox layer.
   - Typical: `exports/iso_whitebox`
 - `--layer`: input layer inside `tiles_dir` (default: `raw_whitebox`)
+- Optional color reference (extra prompt image):
+  - `--ref_tiles_dir`: run-relative directory with a second tile set (e.g. satellite/raw)
+  - `--ref_layer`: layer inside `ref_tiles_dir` (the prompt label is `COLOR REFERENCE`)
 - Patch selection:
   - `--x0 --y0 --w --h` (default `4x4`)
 - Style anchors:
@@ -44,6 +47,8 @@ pnpm -C packages/data iso:vertex:nbpro \
   --run_id=tashkent_local_2026-02-09 \
   --tiles_dir=exports/iso_whitebox \
   --layer=raw_whitebox \
+  --ref_tiles_dir=exports/iso_satellite \
+  --ref_layer=raw_satellite \
   --x0=0 --y0=0 --w=4 --h=4 \
   --out_dir=exports/iso_nb_pro \
   --model=gemini-3-pro-image-preview \
@@ -76,4 +81,3 @@ Key files:
   - Keep `--fallback_model` enabled
   - Reduce `--k` and/or run later
   - Increase retry: `--retry_max`, `--retry_max_ms`
-

--- a/docs/tasks/vertex-nanobanana-4x4-prototype.md
+++ b/docs/tasks/vertex-nanobanana-4x4-prototype.md
@@ -54,7 +54,6 @@ pnpm -C packages/data iso:vertex:nbpro \
   --x0=0 --y0=0 --w=4 --h=4 \
   --out_dir=exports/iso_nb_pro \
   --model=gemini-3-pro-image-preview \
-  --fallback_model=gemini-2.5-flash-image \
   --anchors_dir=exports/anchors/nbpro \
   --prompt_file=exports/prompts/nbpro.txt \
   --negative_prompt_file=exports/prompts/nbpro_negative.txt \

--- a/docs/tasks/vertex-nanobanana-4x4-prototype.md
+++ b/docs/tasks/vertex-nanobanana-4x4-prototype.md
@@ -13,13 +13,15 @@ This is intended to answer: can we get “isometric.nyc-level” quality and wha
 
 ## Prereqs
 
-- `gcloud` installed and authenticated
-  - Either set `VERTEX_ACCESS_TOKEN`, or run:
-    - `gcloud auth application-default login`
-- Env (example):
+- Vertex backend (default):
+  - `gcloud` installed and authenticated
+  - Either set `VERTEX_ACCESS_TOKEN`, or run: `gcloud auth application-default login`
   - `export IMAGE_BACKEND=vertex`
   - `export VERTEX_PROJECT="$(gcloud config get-value project)"`
   - `export VERTEX_LOCATION=global`
+- Gemini backend (optional):
+  - `export IMAGE_BACKEND=gemini`
+  - `export GOOGLE_API_KEY=...`
 
 ## Inputs
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -101,6 +101,8 @@ pnpm data:iso:vertex:nbpro \
   --run_id=tashkent_2026-02-07 \
   --tiles_dir=exports/iso_whitebox \
   --layer=raw_whitebox \
+  --ref_tiles_dir=exports/iso_satellite \
+  --ref_layer=raw_satellite \
   --x0=0 --y0=0 --w=4 --h=4 \
   --out_dir=exports/iso_nb_pro \
   --model=gemini-3-pro-image-preview \

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -89,7 +89,7 @@ pnpm data:image:batch \
 # - Optional thinking controls: --thinking_budget, --thinking_level, --include_thoughts
 # - For gemini-3-pro-image-preview, use VERTEX_LOCATION=global
 # - For IMAGE responses, --candidate_count>1 is emulated via repeated calls (variant seeds)
-# - gemini-2.5 models are intentionally blocked in this repository
+# - Legacy Gemini 2.x models are intentionally blocked in this repository
 
 # Vertex Nano Banana Pro 4x4 pilot (tile-conditioned + seam scoring)
 # - Generates K candidates per tile

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -74,7 +74,6 @@ pnpm data:image:batch \
   --prompts_file=exports/prompts/batch.txt \
   --out_dir=exports/gemini_images \
   --model=gemini-3-pro-image-preview \
-  --fallback_model=gemini-2.5-flash-image \
   --image_size=2K \
   --aspect_ratio=1:1 \
   --temperature=0.45 \
@@ -90,7 +89,7 @@ pnpm data:image:batch \
 # - Optional thinking controls: --thinking_budget, --thinking_level, --include_thoughts
 # - For gemini-3-pro-image-preview, use VERTEX_LOCATION=global
 # - For IMAGE responses, --candidate_count>1 is emulated via repeated calls (variant seeds)
-# - If gemini-3-pro-image-preview returns 429 (Resource exhausted), keep fallback_model enabled
+# - gemini-2.5 models are intentionally blocked in this repository
 
 # Vertex Nano Banana Pro 4x4 pilot (tile-conditioned + seam scoring)
 # - Generates K candidates per tile
@@ -107,7 +106,6 @@ pnpm data:iso:vertex:nbpro \
   --x0=0 --y0=0 --w=4 --h=4 \
   --out_dir=exports/iso_nb_pro \
   --model=gemini-3-pro-image-preview \
-  --fallback_model=gemini-2.5-flash-image \
   --anchors_dir=exports/anchors/nbpro \
   --prompt_file=exports/prompts/nbpro.txt \
   --k=4 --overlap_px=48 --neighbor_mode=left+top \

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -97,6 +97,7 @@ pnpm data:image:batch \
 # - Scores seams vs already accepted neighbors + structure-fidelity vs input tile, selects best
 # - Outputs under exports/iso_nb_pro/: tiles/ + mosaic_nb_pro.png + report_nb_pro.json + seam_heatmap_nb_pro.png
 # - Tip (stylize from real tiles): consider `--neighbors_in_prompt=0` to reduce prompt-induced style collapse
+# - Backend defaults to vertex; use --backend=gemini with GOOGLE_API_KEY for Gemini API backend
 pnpm data:iso:vertex:nbpro \
   --run_id=tashkent_2026-02-07 \
   --tiles_dir=exports/iso_whitebox \

--- a/packages/data/scripts/gemini-image-batch.mjs
+++ b/packages/data/scripts/gemini-image-batch.mjs
@@ -13,6 +13,9 @@ import { findRepoRoot } from './lib/repo-root.mjs';
 
 const execFileAsync = promisify(execFile);
 
+const VERTEX_ACCESS_TOKEN_TTL_MS = 50 * 60 * 1000;
+const vertexTokenCache = { token: '', tsMs: 0 };
+
 function printHelp() {
   console.log(`Usage:
   pnpm data:image:batch --run_id=<id> --prompts_file=<run-rel-file> [options]
@@ -50,6 +53,7 @@ Environment:
     VERTEX_PROJECT (required if model is not a full resource path)
     VERTEX_LOCATION (required if model is not a full resource path, default: us-central1)
     VERTEX_ACCESS_TOKEN (optional, otherwise script tries gcloud auth commands)
+    VERTEX_ACCESS_TOKEN_CMD (optional, shell command that prints an access token; overrides gcloud)
 
 Prompts file format:
   - One prompt per line
@@ -186,7 +190,7 @@ function isForbiddenModel(model) {
   return String(model || '')
     .trim()
     .toLowerCase()
-    .includes('gemini-2.5');
+    .includes('gemini-2.');
 }
 
 function assertModelAllowed(flagName, model) {
@@ -261,9 +265,49 @@ function extractImagesFromResponse(data) {
   throw new Error('No image data in response');
 }
 
-async function getVertexAccessToken() {
+async function getVertexAccessToken({ forceRefresh = false } = {}) {
   const fromEnv = String(process.env.VERTEX_ACCESS_TOKEN || '').trim();
   if (fromEnv) return fromEnv;
+
+  const now = Date.now();
+  if (!forceRefresh && vertexTokenCache.token && now - vertexTokenCache.tsMs < VERTEX_ACCESS_TOKEN_TTL_MS) {
+    return vertexTokenCache.token;
+  }
+
+  const tokenCmd = String(process.env.VERTEX_ACCESS_TOKEN_CMD || '').trim();
+  if (tokenCmd) {
+    const candidates = [];
+    const envShell = String(process.env.SHELL || '').trim();
+    if (envShell) candidates.push(envShell);
+    candidates.push('/bin/bash', '/usr/bin/bash', '/bin/sh');
+    let shellBin = 'bash';
+    for (const c of candidates) {
+      if (await fileExists(c)) {
+        shellBin = c;
+        break;
+      }
+    }
+
+    try {
+      const { stdout, stderr } = await execFileAsync(shellBin, ['-c', tokenCmd], {
+        timeout: 15000,
+        maxBuffer: 1024 * 1024,
+      });
+      const combined = `${String(stdout || '')}\n${String(stderr || '')}`;
+      const lines = combined
+        .split(/\r?\n/)
+        .map((s) => s.trim())
+        .filter(Boolean);
+      const token = lines.length > 0 ? lines[lines.length - 1] : '';
+      if (!token) throw new Error('VERTEX_ACCESS_TOKEN_CMD returned empty token');
+      vertexTokenCache.token = token;
+      vertexTokenCache.tsMs = now;
+      return token;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`VERTEX_ACCESS_TOKEN_CMD failed: ${msg}`);
+    }
+  }
 
   const attempts = [
     ['gcloud', ['auth', 'application-default', 'print-access-token']],
@@ -278,7 +322,11 @@ async function getVertexAccessToken() {
         maxBuffer: 1024 * 1024,
       });
       const token = String(stdout || '').trim();
-      if (token) return token;
+      if (token) {
+        vertexTokenCache.token = token;
+        vertexTokenCache.tsMs = now;
+        return token;
+      }
       errors.push(`${bin} ${args.join(' ')} returned empty token`);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -387,7 +435,6 @@ async function generateImageWithPrompt({
   geminiApiKey,
   vertexProject,
   vertexLocation,
-  vertexAccessToken,
   purpose,
 }) {
   const payload = {
@@ -412,21 +459,43 @@ async function generateImageWithPrompt({
     'Content-Type': 'application/json',
   };
   if (backend === 'vertex') {
-    headers.Authorization = `Bearer ${vertexAccessToken}`;
+    headers.Authorization = `Bearer ${await getVertexAccessToken()}`;
   }
 
-  const data = await postJsonWithRetries({
-    url,
-    payload,
-    purpose,
-    timeoutMs,
-    headers,
-    retryMax,
-    retryBaseMs,
-    retryMaxMs,
-    retryJitterMs,
-    debugRetries,
-  });
+  let data;
+  try {
+    data = await postJsonWithRetries({
+      url,
+      payload,
+      purpose,
+      timeoutMs,
+      headers,
+      retryMax,
+      retryBaseMs,
+      retryMaxMs,
+      retryJitterMs,
+      debugRetries,
+    });
+  } catch (err) {
+    if (backend === 'vertex' && Number(err?.status) === 401) {
+      // Token can expire during long runs; refresh once and retry.
+      headers.Authorization = `Bearer ${await getVertexAccessToken({ forceRefresh: true })}`;
+      data = await postJsonWithRetries({
+        url,
+        payload,
+        purpose,
+        timeoutMs,
+        headers,
+        retryMax,
+        retryBaseMs,
+        retryMaxMs,
+        retryJitterMs,
+        debugRetries,
+      });
+    } else {
+      throw err;
+    }
+  }
 
   return extractImagesFromResponse(data);
 }
@@ -495,7 +564,6 @@ export async function generateImageBatch({
   const vertexProject =
     String(process.env.VERTEX_PROJECT || process.env.GOOGLE_CLOUD_PROJECT || process.env.GCLOUD_PROJECT || '').trim();
   const vertexLocation = String(process.env.VERTEX_LOCATION || process.env.GOOGLE_CLOUD_LOCATION || 'us-central1').trim();
-  const vertexAccessToken = backend === 'vertex' ? await getVertexAccessToken() : '';
   const normalizedImageSize = String(imageSize || '').trim().toUpperCase();
   if (normalizedImageSize && !['1K', '2K', '4K'].includes(normalizedImageSize)) {
     throw new Error(`Invalid --image_size: ${imageSize}. Allowed: 1K, 2K, 4K`);
@@ -575,7 +643,6 @@ export async function generateImageBatch({
               geminiApiKey,
               vertexProject,
               vertexLocation,
-              vertexAccessToken,
               purpose: 'image_generate',
             });
           } catch (err) {
@@ -597,7 +664,6 @@ export async function generateImageBatch({
                   geminiApiKey,
                   vertexProject,
                   vertexLocation,
-                  vertexAccessToken,
                   purpose: 'image_generate_fallback',
                 });
               } catch (fbErr) {

--- a/packages/data/scripts/iso-vertex-nbpro.mjs
+++ b/packages/data/scripts/iso-vertex-nbpro.mjs
@@ -53,6 +53,7 @@ Scoring:
   --structure_weight      Weight for structure-fidelity score (default: 0.75)
   --structure_downscale_px  Downscale px for structure scoring (default: 128)
   --structure_weights     JSON string or path to JSON file (optional)
+  --color_weight          Weight for color fidelity vs reference tile (default: 0.0)
   --fallback_penalty      Additive penalty when fallback model is used (default: 0.05)
 
 Cache:
@@ -203,6 +204,7 @@ export async function runIsoVertexNbpro({
   overlapPx = 48,
   scoreWeights = '',
   structureWeight = 0.75,
+  colorWeight = 0.0,
   structureDownscalePx = 128,
   structureWeights = '',
   fallbackPenalty = 0.05,
@@ -343,6 +345,8 @@ export async function runIsoVertexNbpro({
       '--structure_downscale_px',
       String(Math.trunc(structureDownscalePx)),
       ...(structureWeights ? ['--structure_weights', String(structureWeights)] : []),
+      '--color_weight',
+      String(colorWeight),
       '--fallback_penalty',
       String(fallbackPenalty),
       '--cache_dir',
@@ -460,6 +464,7 @@ async function main() {
       overlapPx: parseNumber(args, 'overlap_px', 48),
       scoreWeights: typeof args.score_weights === 'string' ? args.score_weights : '',
       structureWeight: parseNumber(args, 'structure_weight', 0.75),
+      colorWeight: parseNumber(args, 'color_weight', 0.0),
       structureDownscalePx: parseNumber(args, 'structure_downscale_px', 128),
       structureWeights: typeof args.structure_weights === 'string' ? args.structure_weights : '',
       fallbackPenalty: parseNumber(args, 'fallback_penalty', 0.05),

--- a/packages/data/scripts/iso-vertex-nbpro.mjs
+++ b/packages/data/scripts/iso-vertex-nbpro.mjs
@@ -25,7 +25,7 @@ Vertex:
   --vertex_project        Vertex project (or env VERTEX_PROJECT)
   --vertex_location       Vertex location (default: global)
   --model                 Model id/resource (required)
-  --fallback_model        Fallback model (optional, gemini-2.5 is disallowed in this repo)
+  --fallback_model        Fallback model (optional, gemini-2.x is disallowed in this repo)
 
 Generation:
   --k                     Candidates per tile (default: 4)
@@ -148,7 +148,7 @@ function assertModelAllowed(flagName, modelId) {
     .trim()
     .toLowerCase();
   if (!value) return;
-  if (value.includes('gemini-2.5')) {
+  if (value.includes('gemini-2.')) {
     throw new Error(`${flagName}=${modelId} is not allowed in this repository. Use gemini-3-pro-image-preview.`);
   }
 }

--- a/packages/data/scripts/py/pixel_stylize.py
+++ b/packages/data/scripts/py/pixel_stylize.py
@@ -168,7 +168,8 @@ def main():
         raise SystemExit(f"missing input: {in_path}")
 
     _ensure_dir(os.path.dirname(os.path.abspath(out_path)))
-    img = Image.open(in_path)
+    with Image.open(in_path) as _src:
+        img = _src.convert("RGBA")
 
     out, edge_debug = _stylize(
         img,

--- a/packages/data/scripts/py/vertex_nb_pro_tiles.py
+++ b/packages/data/scripts/py/vertex_nb_pro_tiles.py
@@ -82,6 +82,14 @@ def _normalize_backend(raw):
     raise ValueError(f"Unsupported --backend: {raw}")
 
 
+def _assert_model_allowed(flag_name, model_id):
+    value = str(model_id or "").strip()
+    if not value:
+        return
+    if "gemini-2.5" in value.lower():
+        raise SystemExit(f"{flag_name}={value} is not allowed in this repository. Use gemini-3-pro-image-preview.")
+
+
 def _get_vertex_access_token():
     from_env = str(os.environ.get("VERTEX_ACCESS_TOKEN") or "").strip()
     if from_env:
@@ -500,6 +508,8 @@ def main():
     gemini_api_key = _get_gemini_api_key() if backend == "gemini" else ""
     model = str(args.model).strip()
     fallback_model = str(args.fallback_model or "").strip()
+    _assert_model_allowed("--model", model)
+    _assert_model_allowed("--fallback_model", fallback_model)
 
     cfg = {
         "temperature": float(args.temperature),

--- a/packages/data/scripts/py/vertex_nb_pro_tiles.py
+++ b/packages/data/scripts/py/vertex_nb_pro_tiles.py
@@ -91,7 +91,7 @@ def _assert_model_allowed(flag_name, model_id):
     value = str(model_id or "").strip()
     if not value:
         return
-    if "gemini-2.5" in value.lower():
+    if "gemini-2." in value.lower():
         raise SystemExit(f"{flag_name}={value} is not allowed in this repository. Use gemini-3-pro-image-preview.")
 
 


### PR DESCRIPTION
Changes:
- Add optional color reference input for NBPro tile generation:
  - --ref_tiles_dir + --ref_layer (second prompt image labeled COLOR REFERENCE).
- Include reference tile sha256 in cache key + config + report (avoids cross-tile cache reuse).
- If generation fails and no tiles are produced, skip mosaic build instead of crashing.
- Update docs/examples.

Why:
- Lets us drive geometry from whitebox while preserving real roof colors/materials from satellite/raw tiles, reducing "all roofs brown" collapse.

Files:
- packages/data/scripts/py/vertex_nb_pro_tiles.py
- packages/data/scripts/iso-vertex-nbpro.mjs
- packages/data/README.md
- docs/tasks/vertex-nanobanana-4x4-prototype.md
