### PR TITLE
fix(ci): use GITHUB_TOKEN for workflow dispatch paths

### DIFF
--- a/.github/workflows/codex-autofix-dispatch-batched.yml
+++ b/.github/workflows/codex-autofix-dispatch-batched.yml
@@ -186,7 +186,7 @@ jobs:
           COMMENT_ID: ${{ steps.ctx.outputs.comment_id }}
           COMMENT_KIND: ${{ steps.ctx.outputs.comment_kind }}
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const owner = String(process.env.OWNER || '').trim();
             const repo = String(process.env.REPO_NAME || '').trim();

--- a/.github/workflows/codex-autofix-on-command.yml
+++ b/.github/workflows/codex-autofix-on-command.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Dispatch self-hosted autofix on @codex command
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const issue = context.payload?.issue;
             const comment = context.payload?.comment;

--- a/.github/workflows/codex-autofix-selfhosted.yml
+++ b/.github/workflows/codex-autofix-selfhosted.yml
@@ -43,6 +43,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
   pull-requests: write
   issues: write
 
@@ -731,7 +732,7 @@ jobs:
           REPO: ${{ steps.pr.outputs.repo }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const prNumber = Number(process.env.PR_NUMBER || 0);
             const repoFull = String(process.env.REPO || '');
@@ -801,7 +802,7 @@ jobs:
           COMMENT_ID: ${{ steps.pr.outputs.comment_id }}
           COMMENT_KIND: ${{ steps.pr.outputs.comment_kind }}
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const prNumber = Number(process.env.PR_NUMBER || 0);
             const repoFull = String(process.env.REPO || '');

--- a/.github/workflows/codex-autofix-watchdog.yml
+++ b/.github/workflows/codex-autofix-watchdog.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Cancel stale autofix runs and retry once
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/codex-review-selfhosted.yml
+++ b/.github/workflows/codex-review-selfhosted.yml
@@ -236,7 +236,7 @@ jobs:
           RUNNER_LABEL: ${{ inputs.runner_label }}
           JOB_STATUS: ${{ job.status }}
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const owner = String(process.env.OWNER || '');

--- a/.github/workflows/codex-session-dispatch.yml
+++ b/.github/workflows/codex-session-dispatch.yml
@@ -28,7 +28,9 @@ jobs:
           CODEX_SESSION_DISPATCH_URL: ${{ secrets.CODEX_SESSION_DISPATCH_URL }}
           CODEX_SESSION_DISPATCH_TOKEN: ${{ secrets.CODEX_SESSION_DISPATCH_TOKEN }}
         with:
-          github-token: ${{ secrets.CODEX_REVIEW_TOKEN || secrets.GITHUB_TOKEN }}
+          # Use the workflow token for Actions/Issues APIs; CODEX_REVIEW_TOKEN may be
+          # intentionally limited and cannot dispatch workflows.
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const path = require('path');


### PR DESCRIPTION
## What
Switch dispatch-capable workflow steps to use `github.token` instead of `CODEX_REVIEW_TOKEN || GITHUB_TOKEN` where PAT limitations can break Actions API calls.

## Why
PR #45 showed repeated fallback failures after `@codex review` with:
- `Resource not accessible by personal access token`

Root cause: when `CODEX_REVIEW_TOKEN` is present but limited, github-script picks it first and fails on `actions.createWorkflowDispatch`.

## Changes
- Use `github.token` in dispatch-related github-script steps:
  - `.github/workflows/codex-session-dispatch.yml`
  - `.github/workflows/codex-autofix-on-command.yml`
  - `.github/workflows/codex-autofix-watchdog.yml`
  - `.github/workflows/codex-autofix-dispatch-batched.yml`
  - `.github/workflows/codex-review-selfhosted.yml`
  - `.github/workflows/codex-autofix-selfhosted.yml` (guardrail dispatch paths)
- Add `actions: write` permission to `codex-autofix-selfhosted`.

## Validation
- Parsed all touched workflow YAML files with Ruby Psych parser.